### PR TITLE
README: Use SVG CI badge, remove broken downloads badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,15 +4,11 @@ flaky
 .. image:: http://opensource.box.com/badges/active.svg
     :target: http://opensource.box.com/badges
 
-.. image:: https://travis-ci.org/box/flaky.png?branch=master
+.. image:: https://travis-ci.org/box/flaky.svg?branch=master
     :target: https://travis-ci.org/box/flaky
 
 .. image:: https://img.shields.io/pypi/v/flaky.svg
     :target: https://pypi.python.org/pypi/flaky
-
-.. image:: https://img.shields.io/pypi/dm/flaky.svg
-    :target: https://pypi.python.org/pypi/flaky
-
 
 About
 -----


### PR DESCRIPTION

* Use SVG Travis CI badge for consistency and to make it look better
* Remove broken downloads badge, see https://github.com/badges/shields/issues/716

# Before

![image](https://user-images.githubusercontent.com/1324225/45749251-bf9df200-bc13-11e8-8212-11732e358e26.png)

# After

![image](https://user-images.githubusercontent.com/1324225/45749280-d2b0c200-bc13-11e8-9496-817f0735b3ed.png)
